### PR TITLE
Fix retrieve button visibility for contingency planner

### DIFF
--- a/issues/PLAN-5.md
+++ b/issues/PLAN-5.md
@@ -1,0 +1,30 @@
+# Plan for Issue #5: Visibility retrieve button
+
+## Issue Description
+The retrieve button is visible when playing as the contingency planner at the end of the turn. It should not be visible during the draw cards and infect cities phases.
+
+## Root Cause
+The `updateRetrieveButtonState()` function in `public/js/retrieve_card.js` only checks if:
+1. The current player is the contingency planner
+2. There are discarded action cards available
+3. The player doesn't already have a stored card
+
+It does NOT check the current game phase, so the button remains visible during non-action phases.
+
+## Solution
+Add a phase check to the `updateRetrieveButtonState()` function to ensure the retrieve button is only visible during the `player_actions` phase.
+
+## Implementation Steps
+1. Modify `public/js/retrieve_card.js` line 36-37 to include phase check:
+   ```javascript
+   if (currentPlayer && currentPlayer.role === 'contingency_planner' && gameState.gameStatus.phase === 'player_actions') {
+   ```
+
+2. This aligns with how other action buttons are handled in `action_buttons.js`, which hide during `draw_cards` and `infect_cities` phases.
+
+## Testing Plan
+1. Start a game with a contingency planner
+2. Play actions until end of turn
+3. Verify retrieve button disappears during draw cards phase
+4. Verify retrieve button disappears during infect cities phase
+5. Verify retrieve button reappears during next player's action phase (if they are contingency planner)

--- a/public/js/retrieve_card.js
+++ b/public/js/retrieve_card.js
@@ -33,8 +33,8 @@ export function updateRetrieveButtonState() {
 
   const currentPlayer = getCurrentPlayer();
 
-  // Show the button only for the Contingency Planner
-  if (currentPlayer && currentPlayer.role === 'contingency_planner') {
+  // Show the button only for the Contingency Planner during player actions phase
+  if (currentPlayer && currentPlayer.role === 'contingency_planner' && gameState.gameStatus.phase === 'player_actions') {
     retrieveBtn.style.display = 'flex';
 
     // Get discarded action cards


### PR DESCRIPTION
## Summary
- ✅ Fix retrieve button incorrectly visible at end of turn for contingency planner
- ✅ Add phase check to ensure button only shows during player actions phase

## Issue Description
The retrieve button was showing for the contingency planner during draw cards and infect cities phases when it should only be visible during the player actions phase.

## Changes Made
- Modified `updateRetrieveButtonState()` function in `public/js/retrieve_card.js`
- Added phase check: `gameState.gameStatus.phase === 'player_actions'`
- Aligns button behavior with other action buttons in the game

## Implementation Details
**File**: `public/js/retrieve_card.js:37`
**Before**: 
```javascript
if (currentPlayer && currentPlayer.role === 'contingency_planner') {
```
**After**: 
```javascript
if (currentPlayer && currentPlayer.role === 'contingency_planner' && gameState.gameStatus.phase === 'player_actions') {
```

## Testing
- ✅ Server starts successfully with `bundle exec puma -C config/puma.rb`
- ✅ No JavaScript errors in console
- ✅ Implementation follows existing patterns in `action_buttons.js`
- Manual testing required: verify button visibility during different game phases

## Test plan
- [ ] Start game with contingency planner
- [ ] Verify button visible during player actions phase
- [ ] Verify button disappears during draw cards phase  
- [ ] Verify button disappears during infect cities phase
- [ ] Verify button reappears during next action phase

fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)