### PR TITLE
Fix discard after gift functionality

### DIFF
--- a/issues/PLAN-6.md
+++ b/issues/PLAN-6.md
@@ -1,0 +1,29 @@
+# Plan to Fix Issue #6: Discard After Gift
+
+## Problem
+After giving a card to a player with 7 cards, the discard dialog appears. After choosing a card to discard, an API call is made, but the card is not actually discarded.
+
+## Root Cause
+The JavaScript code in `select_cards.js` is sending `card_indices` to the `/discard_cards` API endpoint, but the Ruby backend expects `card_names`.
+
+## Solution
+Fix the API call in `select_cards.js` to send card names instead of card indices.
+
+### Files to Modify
+1. `public/js/select_cards.js` - Lines 315-328 in the `handleHandLimitCheck` method
+
+### Changes Required
+- Convert selected card indices to card names before sending to API
+- Change the API request from `card_indices: selectedIndices` to `card_names: selectedCardNames`
+
+### Implementation Steps
+1. In the `handleHandLimitCheck` method, map selected indices to card names using the player's current hand
+2. Send the card names array to the `/discard_cards` endpoint
+3. Test the fix by triggering the discard scenario
+
+## Testing Plan
+1. Start a game with multiple players
+2. Use share knowledge to give a card to a player who already has 6 cards
+3. Verify the discard dialog appears
+4. Select a card to discard
+5. Confirm the card is actually removed from the player's hand

--- a/public/js/select_cards.js
+++ b/public/js/select_cards.js
@@ -312,6 +312,9 @@ export function handleHandLimitCheck(playerIndex, discardCount, completionCallba
 
   // Show card selection modal
   showHandSelectionModal(discardCount, cardIndices, async (selectedIndices) => {
+    // Convert selected indices to card names
+    const selectedCardNames = selectedIndices.map(index => player.hand[index].name);
+    
     // Make API call to discard the selected cards
     try {
       const response = await fetch('/discard_cards', {
@@ -321,7 +324,7 @@ export function handleHandLimitCheck(playerIndex, discardCount, completionCallba
         },
         body: JSON.stringify({
           player_index: playerIndex,
-          card_indices: selectedIndices
+          card_names: selectedCardNames
         })
       });
 


### PR DESCRIPTION
## Summary
- Fix the discard functionality that wasn't working after giving cards through share knowledge
- Convert selected card indices to card names before sending to API endpoint
- The /discard_cards endpoint expects card_names array, not card_indices

## Test plan
- [ ] Start a game with multiple players
- [ ] Use share knowledge to give a card to a player who already has 6 cards
- [ ] Verify the discard dialog appears
- [ ] Select a card to discard
- [ ] Confirm the card is actually removed from the player's hand

fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)