### PR TITLE
Fix discard dialog not appearing after draw cards phase

### DIFF
--- a/app/game_state/end_turn.rb
+++ b/app/game_state/end_turn.rb
@@ -22,9 +22,10 @@ class EndTurn
 
     # Check hand limit (7 cards)
     if i == 1 and current_player.hand.size > 7
-      event[:exceeded_hand_limit] = true
-      event[:discard_count] = current_player.hand.size - 7
-      event[:player_index] = @game_state.current_player_idx
+      event[:exceeded_hand_limit] = {
+        discard_count: current_player.hand.size - 7,
+        player_index: @game_state.current_player_idx
+      }
       puts event.inspect
     end
 

--- a/app/game_state/player_actions.rb
+++ b/app/game_state/player_actions.rb
@@ -219,7 +219,7 @@ module PlayerActions
     if current_player.hand.size > 7
       exceeded_limit = {
         player_index: current_player_idx,
-        excess_cards: current_player.hand.map(&:name).last(current_player.hand.size - 7)
+        discard_count: current_player.hand.size - 7
       }
       response = after_action(true, "Successfully retrieved '#{action_card_name}' action card")
       response[:exceeded_hand_limit] = exceeded_limit

--- a/issues/PLAN-26.md
+++ b/issues/PLAN-26.md
@@ -1,0 +1,47 @@
+# PLAN: Fix No Discard Dialog After Draw Cards Phase (Issue #26)
+
+## Problem Analysis
+
+The discard dialog is not appearing after the draw cards phase when a player exceeds the hand limit (7 cards). 
+
+### Root Cause
+There's a **data structure mismatch** between backend and frontend:
+
+**Backend** (`app/game_state/end_turn.rb:24-29`):
+```ruby
+event[:exceeded_hand_limit] = true
+event[:discard_count] = current_player.hand.size - 7
+event[:player_index] = @game_state.current_player_idx
+```
+
+**Frontend** (`public/js/end_turn_events.js:162-168`):
+```javascript
+const nrCardsToDiscard = eventToAnimate.exceeded_hand_limit.discard_count;
+const playerIndex = eventToAnimate.exceeded_hand_limit.player_index;
+```
+
+The backend sets `exceeded_hand_limit` as a boolean flag with separate `discard_count` and `player_index` properties, but the frontend expects `exceeded_hand_limit` to be an object containing `discard_count` and `player_index`.
+
+## Solution
+
+Fix the backend to structure the `exceeded_hand_limit` data as an object that matches frontend expectations.
+
+### Changes Required
+
+1. **Backend Fix** (`app/game_state/end_turn.rb`):
+   - Change the data structure to nest `discard_count` and `player_index` under `exceeded_hand_limit`
+
+2. **Testing**:
+   - Verify hand limit logic works correctly during draw cards phase
+   - Test discard dialog appearance and functionality
+   - Ensure game continues properly after discarding
+
+### Implementation Plan
+
+1. Modify `app/game_state/end_turn.rb` to structure the exceeded hand limit data correctly
+2. Run tests to ensure no regressions
+3. Manual testing of the discard flow during end turn
+
+## Expected Outcome
+
+When a player draws cards at the end of their turn and exceeds the 7-card hand limit, a discard dialog should appear allowing them to select cards to discard before the infection phase begins.

--- a/test/test_game_state.rb
+++ b/test/test_game_state.rb
@@ -184,4 +184,37 @@ class TestGameState < TestHelper
     assert data['gameStatus']['currentPlayerIndex'].is_a?(Integer)
     assert data['gameStatus']['actions_remaining'].is_a?(Integer)
   end
+
+  def test_exceeded_hand_limit_structure_in_draw_cards
+    # Create a game state with player having 6 cards
+    game_state = create_test_game_state(:normal, 2)
+
+    # Clear the current player's hand and add exactly 6 cards
+    current_player = game_state.current_player
+    current_player.hand.clear
+
+    require_relative '../app/game_state/card'
+    ['Chicago', 'Montreal', 'Washington', 'New York', 'London', 'Paris'].each do |city|
+      current_player.hand << Card.new(:city, city, :blue)
+    end
+
+    # Ensure player deck has at least 2 cards for drawing
+    game_state.player_deck.clear
+    game_state.player_deck << Card.new(:city, 'Barcelona', :yellow)
+    game_state.player_deck << Card.new(:city, 'Madrid', :yellow)
+
+    # Call draw_cards which should trigger hand limit check on second card
+    result = game_state.draw_cards
+
+    # Find the event with exceeded_hand_limit
+    exceeded_event = result[:events].find { |event| event[:exceeded_hand_limit] }
+
+    # Verify the event exists and has correct structure
+    refute_nil exceeded_event, "Should have an event with exceeded_hand_limit"
+
+    exceeded_limit_data = exceeded_event[:exceeded_hand_limit]
+    assert exceeded_limit_data.is_a?(Hash), "exceeded_hand_limit should be a Hash"
+    assert_equal 1, exceeded_limit_data[:discard_count]
+    assert_equal game_state.current_player_idx, exceeded_limit_data[:player_index]
+  end
 end


### PR DESCRIPTION
## Summary
- ✅ Fixed data structure mismatch preventing discard dialog from appearing after draw cards phase
- ✅ Backend now returns `exceeded_hand_limit` as object containing `discard_count` and `player_index`
- ✅ Updated both `app/game_state/end_turn.rb` and `app/game_state/player_actions.rb` for consistency
- ✅ Added comprehensive test to verify correct data structure
- ✅ Applied rubocop style fixes

## Root Cause
The backend was setting `exceeded_hand_limit` as a boolean flag with separate `discard_count` and `player_index` properties:
```ruby
event[:exceeded_hand_limit] = true
event[:discard_count] = current_player.hand.size - 7
event[:player_index] = @game_state.current_player_idx
```

But the frontend expected `exceeded_hand_limit` to be an object:
```javascript
const nrCardsToDiscard = eventToAnimate.exceeded_hand_limit.discard_count;
const playerIndex = eventToAnimate.exceeded_hand_limit.player_index;
```

## Solution
Changed backend to structure the data correctly:
```ruby
event[:exceeded_hand_limit] = {
  discard_count: current_player.hand.size - 7,
  player_index: @game_state.current_player_idx
}
```

## Test plan
- [x] Added test `test_exceeded_hand_limit_structure_in_draw_cards` that verifies correct data structure
- [x] Existing discard cards test passes
- [x] Ran `rake test` - all tests pass except unrelated redirect test
- [x] Applied `rubocop -A` style fixes

The discard dialog should now properly appear when players exceed the 7-card hand limit during the draw cards phase at end of turn.

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)