### PR TITLE
Fix Operations Expert special move HTTP status code

### DIFF
--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -199,7 +199,12 @@ class GameController < ApplicationController
 
   def render_game_result(result)
     if result[:success] == false
-      render json: result, status: 422
+      # Handle card_required responses with 200 status instead of 422
+      if result[:status] == 'card_required'
+        render json: result
+      else
+        render json: result, status: 422
+      end
     else
       render json: result
     end

--- a/issues/PLAN-53.md
+++ b/issues/PLAN-53.md
@@ -1,0 +1,39 @@
+# PLAN-53: Operations Expert Special Move Status Code Fix
+
+## Problem Description
+When an Operations Expert attempts a special move from a research station without specifying a card, the backend correctly responds with `{"status": "card_required"}` but incorrectly returns this with a 422 HTTP status code instead of 200. This causes the frontend to potentially not display the card selection dialog properly.
+
+## Root Cause Analysis
+1. **Backend Issue**: In `app/game_state/player_actions.rb` (lines 20-26), the Operations Expert special move logic returns `{success: false, status: 'card_required', ...}` when a card is required.
+
+2. **Controller Issue**: In `app/controllers/game_controller.rb` (line 202), the `render_game_result` method treats ANY result with `success: false` as an error and returns it with status 422.
+
+3. **Frontend Expectation**: In `public/js/player_action_utils.js` (lines 93-102), the frontend correctly handles `result.status === 'card_required'` for move operations, expecting it to be a valid response that triggers card selection UI.
+
+## Proposed Solution
+Modify the controller's `render_game_result` method to distinguish between actual errors and valid "card_required" responses. When `status: 'card_required'`, return HTTP 200 instead of 422.
+
+## Implementation Plan
+1. **Modify `render_game_result` method** in `app/controllers/game_controller.rb`:
+   - Check if `result[:status] == 'card_required'`
+   - Return HTTP 200 for card_required responses
+   - Keep 422 for actual errors (status: 'error', etc.)
+
+2. **Test the fix**:
+   - Create/update test case for Operations Expert special move
+   - Verify 200 status code is returned for card_required responses
+   - Verify 422 is still returned for actual errors
+
+3. **Verify frontend behavior**:
+   - Test that card selection dialog appears correctly
+   - Ensure no regression in error handling
+
+## Files to Modify
+- `app/controllers/game_controller.rb` - Update `render_game_result` method
+- `test/test_api_endpoints.rb` - Add/update test cases
+
+## Expected Outcome
+- Operations Expert special move will return HTTP 200 with `{"status": "card_required"}`
+- Frontend will properly display card selection dialog
+- Error responses will still return appropriate 422 status codes
+- No regression in existing functionality

--- a/test/test_api_endpoints.rb
+++ b/test/test_api_endpoints.rb
@@ -352,7 +352,8 @@ class TestApiEndpoints < TestHelper
       # No card_name specified
     }.to_json, { 'CONTENT_TYPE' => 'application/json' }
 
-    assert_equal 422, last_response.status
+    # Should return 200 for card_required responses (not 422)
+    assert_equal 200, last_response.status
     assert_json_response(last_response)
 
     data = parse_json_response(last_response)

--- a/test/test_sessions_controller.rb
+++ b/test/test_sessions_controller.rb
@@ -97,10 +97,10 @@ class TestSessionsController < TestHelper
     # Test that OAuth endpoint accepts POST requests (not GET)
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(@auth_hash)
-    
+
     # POST to OAuth endpoint should work
     post '/auth/google_oauth2'
-    
+
     # Should redirect to callback
     assert last_response.redirect?
     assert_includes last_response.location, '/auth/google_oauth2/callback'
@@ -109,7 +109,7 @@ class TestSessionsController < TestHelper
   def test_oauth_endpoint_rejects_get_requests
     # Test that OAuth endpoint rejects GET requests for security
     get '/auth/google_oauth2'
-    
+
     # Should return 404 (method not allowed by OmniAuth)
     assert_equal 404, last_response.status
   end


### PR DESCRIPTION
## Summary
- Fixed Operations Expert special move returning 422 instead of 200 when card selection is required
- Modified render_game_result method to properly handle card_required responses
- Updated test to expect 200 status code for valid card_required scenarios
- Ensures frontend card selection dialog works correctly

## Changes Made
- **app/controllers/game_controller.rb**: Updated `render_game_result` to return HTTP 200 for `card_required` responses
- **test/test_api_endpoints.rb**: Updated test to expect 200 status for Operations Expert card selection scenarios
- **issues/PLAN-53.md**: Added implementation plan documenting the issue and solution

## Test plan
- [x] Test Operations Expert special move without card parameter returns 200 status
- [x] Test card selection dialog logic remains functional
- [x] Test actual errors still return 422 status
- [x] Run existing test suite to ensure no regressions (all tests pass)

## Root Cause
The backend was treating "card_required" responses as errors and returning 422 status codes, even though this is a valid game state that should trigger the frontend card selection UI. The frontend correctly handled card_required responses but may have been affected by the incorrect HTTP status.

## Solution
Modified the controller to distinguish between actual errors (which should return 422) and valid "card_required" responses (which should return 200), ensuring proper frontend behavior.

fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)