### PR TITLE
Move git commit hash to player list

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -34,15 +34,12 @@
   <script type="module" src="/js/scrolling.js"></script>
   <script type="module" src="/js/retrieve_card.js"></script>
 </head>
-<body>
+<body<%= Rails.env.production? ? " data-git-hash=\"#{File.read('.git/refs/heads/trunk').strip[0..5] rescue ''}\"".html_safe : '' %>>
   <div class="game-header">
     <div class="logo-container">
       <h1>PANDEMIC</h1>
       <h2>Global Disease Control</h2>
     </div>
-    <% if Rails.env.production? %>
-      <span class="git-hash"><%= File.read('.git/refs/heads/trunk').strip[0..5] rescue nil %></span>
-    <% end %>
     <div class="auth-container">
       <div id="auth-info" style="display: none;">
         <span class="user-name"></span>

--- a/issues/PLAN-43.md
+++ b/issues/PLAN-43.md
@@ -1,0 +1,48 @@
+# PLAN-43: Move Git Commit Hash
+
+## Issue Summary
+Move git commit hash from the header to the top left of the `.player-list` element.
+
+## Context
+- PR #24 implemented git commit hash display in the header
+- Issue #43 requests moving this display to the player list area
+- The git commit hash currently shows the first 6 characters (e.g., bf3b98b)
+
+## Implementation Plan
+
+### 1. Locate Current Implementation
+- [x] Find where git commit hash is currently displayed in header
+- [x] Identify the current implementation code
+
+### 2. Remove from Header
+- [ ] Remove git commit hash display from header
+- [ ] Clean up related CSS styling for header version
+
+### 3. Add to Player List
+- [ ] Modify player panel JavaScript to include git commit hash
+- [ ] Add git commit hash to top left of `.player-list` element
+- [ ] Style the commit hash appropriately (small, inconspicuous)
+
+### 4. Implementation Details
+- [ ] Update `public/js/player_panel.js` to add commit hash display
+- [ ] Update `public/css/player_panel.css` to style the commit hash
+- [ ] Ensure commit hash is visible but not prominent
+- [ ] Position in top-left corner of player list
+
+### 5. Testing
+- [ ] Verify git commit hash appears in player list
+- [ ] Verify git commit hash is removed from header
+- [ ] Test visual positioning and styling
+- [ ] Test in both development and production environments
+
+## Expected Changes
+- **Modified files**: 
+  - `app/views/application/index.html.erb` (remove from header)
+  - `public/js/player_panel.js` (add to player list)
+  - `public/css/player_panel.css` (styling)
+
+## Success Criteria
+- Git commit hash (first 6 characters) displays in top-left of `.player-list`
+- Git commit hash is removed from header
+- Visual styling is clean and inconspicuous
+- No regression in existing functionality

--- a/public/css/player_panel.css
+++ b/public/css/player_panel.css
@@ -98,6 +98,19 @@
   display: flex;
   flex-direction: column;
   gap: 15px;
+  position: relative;
+}
+
+.git-hash-display {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  color: rgba(0, 0, 0, 0.3);
+  font-size: 10px;
+  font-family: monospace;
+  letter-spacing: 0.5px;
+  z-index: 10;
+  pointer-events: none;
 }
 
 .player-item {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -142,12 +142,3 @@ button {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.git-hash {
-  color: rgba(255, 255, 255, 0.4);
-  font-size: 11px;
-  font-family: monospace;
-  letter-spacing: 0.5px;
-  margin-left: auto;
-  margin-right: 15px;
-}
-EOF < /dev/null

--- a/public/js/player_panel.js
+++ b/public/js/player_panel.js
@@ -65,6 +65,13 @@ function createPlayerPanel() {
 
   // Create player list container
   const listContainer = createSimpleElement('div', 'player-list');
+  
+  // Add git commit hash to top-left of player list (production only)
+  const gitHashData = document.body.getAttribute('data-git-hash');
+  if (gitHashData && gitHashData.trim()) {
+    const gitHash = createSimpleElement('div', 'git-hash-display', gitHashData);
+    listContainer.appendChild(gitHash);
+  }
 
   // Assemble the panel
   panel.appendChild(header);

--- a/test/test_api_endpoints.rb
+++ b/test/test_api_endpoints.rb
@@ -13,6 +13,14 @@ class TestApiEndpoints < TestHelper
     refute_includes last_response.body, 'git-hash', 'Git hash should not be displayed in development environment'
   end
 
+  def test_git_hash_moved_to_player_list
+    # This test verifies the structure is in place for production git hash display
+    get '/'
+    assert_equal 200, last_response.status
+    # In development, no data-git-hash attribute should be present
+    refute_includes last_response.body, 'data-git-hash', 'data-git-hash attribute should not be present in development'
+  end
+
   def test_game_state_json_endpoint
     create_test_game_state
 

--- a/test/test_sessions_controller.rb
+++ b/test/test_sessions_controller.rb
@@ -97,10 +97,10 @@ class TestSessionsController < TestHelper
     # Test that OAuth endpoint accepts POST requests (not GET)
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(@auth_hash)
-    
+
     # POST to OAuth endpoint should work
     post '/auth/google_oauth2'
-    
+
     # Should redirect to callback
     assert last_response.redirect?
     assert_includes last_response.location, '/auth/google_oauth2/callback'
@@ -109,7 +109,7 @@ class TestSessionsController < TestHelper
   def test_oauth_endpoint_rejects_get_requests
     # Test that OAuth endpoint rejects GET requests for security
     get '/auth/google_oauth2'
-    
+
     # Should return 404 (method not allowed by OmniAuth)
     assert_equal 404, last_response.status
   end


### PR DESCRIPTION
## Summary
- Move git commit hash from header to top-left of .player-list
- Implement the change requested in issue #43
- Relocate commit hash display while maintaining inconspicuous styling

## Test plan
- [ ] Remove git commit hash from header
- [ ] Add git commit hash to player list
- [ ] Verify visual positioning and styling
- [ ] Test in both development and production environments

🤖 Generated with [Claude Code](https://claude.ai/code)