### PR TITLE
Make action cards button 10% bigger

### DIFF
--- a/issues/PLAN-action-cards-button-68.md
+++ b/issues/PLAN-action-cards-button-68.md
@@ -1,0 +1,28 @@
+# Plan for Issue #68: Action Cards Button
+
+## Issue Summary
+Make element with id action-cards-btn 10% bigger.
+
+## Analysis
+The action-cards-btn element is defined in `/public/js/action_cards.js` and styled in `/public/css/buttons.css`. The button has both `.action-btn` and `.special-action` classes applied.
+
+Current dimensions for `.action-btn.special-action`:
+- Width: 80px
+- Height: 120px
+
+## Implementation Plan
+1. Increase the width from 80px to 88px (10% increase)
+2. Increase the height from 120px to 132px (10% increase)
+3. Proportionally adjust related properties:
+   - Font sizes for icon and text
+   - Padding and margins
+   - Card header dimensions
+
+## Files to Modify
+- `/public/css/buttons.css` - Update the `.action-btn.special-action` styles
+
+## Testing Approach
+- Visual inspection to ensure the button looks correct
+- Verify the button still functions properly when clicked
+- Check responsive behavior on different screen sizes
+- Ensure no overlap with other UI elements

--- a/public/css/buttons.css
+++ b/public/css/buttons.css
@@ -77,8 +77,8 @@
   right: 20px;
   color: #ffeb99;
   /* Card-like appearance in portrait mode */
-  width: 80px;
-  height: 120px;
+  width: 88px;
+  height: 132px;
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   padding: 6px 5px;
@@ -113,13 +113,13 @@
 
 /* Adjust card icon and text for portrait orientation */
 .action-btn.special-action i {
-  font-size: 36px;
-  margin-top: 20px;  /* Space for the header */
-  margin-bottom: 8px;
+  font-size: 40px;
+  margin-top: 22px;  /* Space for the header */
+  margin-bottom: 9px;
 }
 
 .action-btn.special-action span {
-  font-size: 12px;
+  font-size: 13px;
   max-width: 90%;
   font-weight: bold;
   text-align: center;

--- a/test/test_action_cards_button_size.rb
+++ b/test/test_action_cards_button_size.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class TestActionCardsButtonSize < Minitest::Test
+  def test_action_cards_button_css_dimensions
+    css_file = File.read(File.join(__dir__, '..', 'public', 'css', 'buttons.css'))
+
+    # Test that the action-btn.special-action width is 88px (10% bigger than original 80px)
+    assert_match(/\.action-btn\.special-action\s*\{[^}]*width:\s*88px/, css_file,
+                 "Action cards button width should be 88px")
+
+    # Test that the action-btn.special-action height is 132px (10% bigger than original 120px)
+    assert_match(/\.action-btn\.special-action\s*\{[^}]*height:\s*132px/, css_file,
+                 "Action cards button height should be 132px")
+
+    # Test that the icon font-size is 40px (proportionally increased from 36px)
+    assert_match(/\.action-btn\.special-action\s+i\s*\{[^}]*font-size:\s*40px/, css_file,
+                 "Action cards button icon font-size should be 40px")
+
+    # Test that the text font-size is 13px (proportionally increased from 12px)
+    assert_match(/\.action-btn\.special-action\s+span\s*\{[^}]*font-size:\s*13px/, css_file,
+                 "Action cards button text font-size should be 13px")
+  end
+end


### PR DESCRIPTION
## Summary
- Increase the action-cards-btn element size by 10% to improve visibility

## Changes
- Updated CSS dimensions for the action cards button
  - Width: 80px → 88px (10% increase)
  - Height: 120px → 132px (10% increase)
- Proportionally adjusted related styling properties
  - Icon font-size: 36px → 40px
  - Text font-size: 12px → 13px
  - Icon margin-top: 20px → 22px

## Testing
- All existing tests pass (66 runs, 329 assertions, 0 failures)
- Added new test `test_action_cards_button_size.rb` to verify CSS dimensions
- Verified code style with rubocop

fixes #68

🤖 Generated with [Claude Code](https://claude.ai/code)